### PR TITLE
v1.1.0に上げる

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,3 @@
 YAHOO_API_KEY="ref: https://e.developer.yahoo.co.jp/dashboard/"
 DICTIONARY_YML_PATH="your own dicionary file(ex: ./spec/dictionary.yml)"
+NO_FILTER="ref: https://developer.yahoo.co.jp/webapi/jlp/kousei/v1/kousei.html #no_filter"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# ChangeLog
+
+## v1.1.0
+
+- 辞書ファイルの記述を簡略化できるよう修正した
+- API側の検知レベルを `.env` から調整できるようにした
+- `正しい単語の文字長 < 誤りのある単語の文字長` を検知できるようにした
+
+```ruby
+# dictionary.yml
+# -
+#   correct: word
+#   wrongs:
+#     - words
+
+# 修正前：
+Jkproof.detect_words_has_error("words is wrong.")
+# => []
+
+# 修正後：
+Jkproof.detect_words_has_error("words is wrong.")
+# => [{ correct: "word", wrong: "words" }]
+
+# これは内部的な処理が次のようになっていたため発生していた。
+# 1.正しい単語を除去
+# 2.誤りのある単語を検知
+```
+
+## v1.0.0
+
+- APIキー・辞書ファイルのパス（ `dictionary.yml` ）を `.env` に記述できるようにした 
+
+正式版としてリリース。
+
+## v0.1.0
+プレリリース。

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jkproof (0.1.0)
+    jkproof (1.0.0)
       activesupport
       dotenv
       highline

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'jkproof'

--- a/jkproof.gemspec
+++ b/jkproof.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'jkproof/version'
@@ -17,7 +19,7 @@ Gem::Specification.new do |spec|
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "https://rubygems.org"
+    spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
     # spec.metadata["homepage_uri"] = spec.homepage
     spec.metadata['homepage_uri']    = 'https://github.com/tosite0345/jkproof'
@@ -41,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'xml-simple'
   spec.add_dependency 'dotenv'
   spec.add_dependency 'highline'
+  spec.add_dependency 'xml-simple'
 end

--- a/lib/jkproof.rb
+++ b/lib/jkproof.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'jkproof/version'
 require 'jkproof/sentence'
 

--- a/lib/jkproof/sentence.rb
+++ b/lib/jkproof/sentence.rb
@@ -12,7 +12,7 @@ module Jkproof
       yml_path       = ENV["DICTIONARY_YML_PATH"]
       @yahoo_api_key = ENV["YAHOO_API_KEY"]
       begin
-        @dictionary_words = (yml_path.blank?) ? [] : YAML.load_file(yml_path+"-")
+        @dictionary_words = (yml_path.blank?) ? [] : YAML.load_file(yml_path)
       rescue => e
         raise "#{e}(file_path: '#{yml_path}')"
       end
@@ -25,7 +25,9 @@ module Jkproof
       wrong_words = []
 
       # 正しいワードを取り除く
-      @dictionary_words.each do |_key, word|
+      @dictionary_words.each do |word|
+        puts word
+        puts '----'
         @buf.gsub!(word['correct'], '')
       end
 

--- a/lib/jkproof/sentence.rb
+++ b/lib/jkproof/sentence.rb
@@ -9,11 +9,15 @@ module Jkproof
 
     def initialize(buf)
       Dotenv.load
-      yml_path          = ENV["DICTIONARY_YML_PATH"]
-      @yahoo_api_key    = ENV["YAHOO_API_KEY"]
-      @dictionary_words = (yml_path.blank?) ? [] : YAML.load_file(yml_path)
-      @yahoo_words      = []
-      @buf              = buf
+      yml_path       = ENV["DICTIONARY_YML_PATH"]
+      @yahoo_api_key = ENV["YAHOO_API_KEY"]
+      begin
+        @dictionary_words = (yml_path.blank?) ? [] : YAML.load_file(yml_path+"-")
+      rescue => e
+        raise "#{e}(file_path: '#{yml_path}')"
+      end
+      @yahoo_words = []
+      @buf         = buf
       fetch_yahoo_lint_words
     end
 

--- a/lib/jkproof/version.rb
+++ b/lib/jkproof/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Jkproof
-  VERSION = '1.0.0' # バージョンアップ
+  VERSION = '1.1.0' # バージョンアップ
 end

--- a/lib/jkproof/version.rb
+++ b/lib/jkproof/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Jkproof
   VERSION = '1.0.0' # バージョンアップ
 end

--- a/spec/dictionary.yml
+++ b/spec/dictionary.yml
@@ -1,10 +1,14 @@
 -
-  correct : お問い合わせ
-  wrongs  :
+  correct: お問い合わせ
+  wrongs:
     - 問い合わせ
     - お問合せ
     - 問合せ
 -
-  correct : Web
-  wrongs  :
+  correct: Web
+  wrongs:
     - WEB
+-
+  correct: 税抜
+  wrongs:
+    - 税抜き

--- a/spec/dictionary.yml
+++ b/spec/dictionary.yml
@@ -1,10 +1,10 @@
-word1:
+-
   correct : お問い合わせ
   wrongs  :
     - 問い合わせ
     - お問合せ
     - 問合せ
-word2:
+-
   correct : Web
   wrongs  :
     - WEB

--- a/spec/dictionary.yml
+++ b/spec/dictionary.yml
@@ -1,10 +1,10 @@
 word1:
   correct : お問い合わせ
   wrongs  :
-    word1: 問い合わせ
-    word2: お問合せ
-    word3: 問合せ
+    - 問い合わせ
+    - お問合せ
+    - 問合せ
 word2:
   correct : Web
   wrongs  :
-    word1: WEB
+    - WEB

--- a/spec/jkproof_spec.rb
+++ b/spec/jkproof_spec.rb
@@ -59,4 +59,13 @@ RSpec.describe Jkproof do
     actual = Jkproof.detect_words_has_error(buf)
     expect(actual).to eq expect
   end
+
+  it '正しいワードよりも誤ったワードのほうが文字数が長い場合' do
+    expect = [
+      { wrong: '税抜き', correct: '税抜' }
+    ]
+    buf    = '税抜き表記は誤りです。税抜が正しい。'
+    actual = Jkproof.detect_words_has_error(buf)
+    expect(actual).to eq expect
+  end
 end

--- a/spec/jkproof_spec.rb
+++ b/spec/jkproof_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Jkproof do
   it 'バージョンを持っている' do
     expect(Jkproof::VERSION).not_to be nil
@@ -24,7 +26,7 @@ RSpec.describe Jkproof do
 
   it 'どちらも合致する場合' do
     expect = [
-      { wrong: 'お問合せ', correct: 'お問い合わせ' },
+      { correct: 'お問い合わせ', wrong: 'お問合せ' },
       { correct: 'ください', wrong: '下さい' },
       { correct: 'いたします', wrong: '致します' }
     ]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 require 'jkproof'
 


### PR DESCRIPTION
# 変更履歴

- 検出レベルを `.env` から調整できるようにした
- `dictionary.yml` の記述を簡略化した
- `正しい単語の文字長 < 誤っている単語の文字長` の場合に正しく検知できるようにした